### PR TITLE
net.c: pass sizeof sockaddr_in struct to bind()

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -174,7 +174,7 @@ static SOCKET grab_port(unsigned short port, const char * addr, int socktype) {
     setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(int));
 
     /* Bind the socket to port. */
-    if (bind(sock, (struct sockaddr *) &bind_addr, sizeof(bind_addr)) == -1) {
+    if (bind(sock, (struct sockaddr *) &bind_addr, sizeof(struct sockaddr_in)) == -1) {
         server_failure_reason = bind_id;
         return SOCKET_ERROR;
     }


### PR DESCRIPTION
macOS (possibly others?) does not like `sizeof sockaddr_storage` being passed to bind() and returns an `Invalid argument` error when attempting to bind ports on startup.

This changes the call to instead use `sizeof(struct sockaddr_in)` (which assumes IPv4 but so does the rest of the function).

I've tested this on macOS and Linux and it seems to work just fine.